### PR TITLE
keep the last char for password generator

### DIFF
--- a/src/main/java/org/hybridai/password/PasswordEndpoint.java
+++ b/src/main/java/org/hybridai/password/PasswordEndpoint.java
@@ -28,7 +28,9 @@ public class PasswordEndpoint {
         long start = System.currentTimeMillis();
         String password = passwordGenerator.generatePassword(message).trim();
         int length = 0;
-        while (length < password.length()-1 && Character.isLetter(password.charAt(++length)));
+        while (length < password.length() && Character.isLetter(password.charAt(length))) {
+            length++;
+        }
         password = password.substring(0, length);
         long llmResponse = System.currentTimeMillis();
         LOG.info( "LLM processing time: " + (llmResponse - start) + " msecs" );


### PR DESCRIPTION
Very minor fix.

The current code removes the last character when LLM responds with a simple word that consists of characters.

for example, when posting `blue`,
```
2024-06-14 11:47:27,406 INFO  [io.qua.lan.oll.OllamaRestApi$OllamaLogger] (vert.x-eventloop-thread-0) Response:
- status code: 200
- headers: [Content-Type: application/json; charset=utf-8], [Date: Fri, 14 Jun 2024 02:47:27 GMT], [Content-Length: 478]
- body: {"model":"mistral","created_at":"2024-06-14T02:47:27.364021976Z","response":" Sapphire","done":true,"done_reason":"stop","context":[3,6438,1032,6277,2475,3229,1032,3735,10146,1163,1224,3013,1232,13117,4903,5339,1633,1392,3460,2475,1072,3279,1880,2439,1475,5638,5807,1210,5285,1210,22963,10991,29491,29473,4,1086,1145,1489,1304],"total_duration":2791065172,"load_duration":4035979,"prompt_eval_count":22,"prompt_eval_duration":2034711000,"eval_count":5,"eval_duration":709926000}

2024-06-14 11:47:27,407 INFO  [org.hyb.ref.RefundChatbotEndpoint] (executor-thread-1) LLM processing time: 2839 msecs
2024-06-14 11:47:27,407 INFO  [org.hyb.ref.RefundChatbotEndpoint] (executor-thread-1) Generated word: Sapphir
No special char in Sapphir
No digit in S@pphir
Too short S@pph1r
```

LLM response `Sapphire` is trimmed to `Sapphir`.